### PR TITLE
feat(ci): install worker-build from repo

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -130,10 +130,16 @@ func (m *SunApi) wranglerContainer() *dagger.Container {
 			"clang",
 			"wasm-tools",
 			"curl",
+			"worker-build",
+		},
+		ExtraRepositories: []string{
+			"https://moosingin3space.github.io/wolfi-pkgs",
+		},
+		ExtraKeyUrls: []string{
+			"https://moosingin3space.github.io/wolfi-pkgs/melange.rsa.pub",
 		},
 	})).
-		WithExec([]string{"rustup", "target", "add", "wasm32-unknown-unknown"}).
-		WithExec([]string{"cargo", "install", "worker-build"})
+		WithExec([]string{"rustup", "target", "add", "wasm32-unknown-unknown"})
 }
 
 // withCfWorkerSource mounts source and sets workdir to the CF worker directory with npm caching

--- a/dagger.json
+++ b/dagger.json
@@ -7,8 +7,8 @@
   "dependencies": [
     {
       "name": "wolfi",
-      "source": "github.com/dagger/dagger/modules/wolfi@v0.19.8",
-      "pin": "1c8379708f82e0f1543fbc0a806b4b995793e55b"
+      "source": "github.com/moosingin3space/dagger/modules/wolfi@moosnat/push-yxlotqupsspr",
+      "pin": "a41dadde1afed8257cccde556d4bddb3f7fdc7af"
     }
   ],
   "source": ".dagger"


### PR DESCRIPTION
This patch replaces `worker-build` with one from a repository, speeding up builds.