### PR TITLE
fix(cf): add console_error_panic_hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +792,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1423,7 +1433,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1689,6 +1699,7 @@ name = "sunapi-cf"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "console_error_panic_hook",
  "jiff",
  "sunapi",
  "tower",
@@ -2206,7 +2217,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/sunapi-cf/Cargo.toml
+++ b/sunapi-cf/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 axum = { version = "0.8.7", default-features = false }
+console_error_panic_hook = "0.1.7"
 jiff = { version = "0.2.16", default-features = false, features = ["js"] }
 sunapi = { version = "0.1.0", path = "../sunapi", default-features = false }
 tower = "0.5.2"

--- a/sunapi-cf/src/lib.rs
+++ b/sunapi-cf/src/lib.rs
@@ -21,6 +21,8 @@ impl Platform for CloudflarePlatform {
 
 #[event(fetch)]
 async fn fetch(req: HttpRequest, _env: Env, _ctx: Context) -> Result<Response> {
+    console_error_panic_hook::set_once();
+
     let plat = CloudflarePlatform;
     let router = sunapi::create_router(plat);
 


### PR DESCRIPTION
Now, panics will actually log to the Cloudflare Dashboard.