### PR TITLE
fix: make dagger-update pipelines trigger dispatch

### DIFF
--- a/.github/workflows/dagger-update.yml
+++ b/.github/workflows/dagger-update.yml
@@ -32,4 +32,17 @@ jobs:
                     git config user.name "github-actions[bot]"
                     git commit --amend --no-edit
                     git push --force-with-lease origin HEAD
+                    echo "PUSHED=true" >> $GITHUB_ENV
                   fi
+
+            - name: Trigger PR checks
+              if: env.PUSHED == 'true'
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      github.rest.repos.createDispatchEvent({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        event_type: 'dagger-update-complete'
+                      })

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: PR Checks
 on:
     pull_request:
         branches: [main]
+    repository_dispatch:
+        types: [dagger-update-complete]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,6 +5,8 @@ on:
         branches: [main]
     pull_request:
         branches: ["**"]
+    repository_dispatch:
+        types: [dagger-update-complete]
 
 permissions: {}
 


### PR DESCRIPTION
This patch ensures that the PR pipelines get triggered correctly after a `dagger-update` occurs.